### PR TITLE
Minor updates in preparation for 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Below are Maven dependencies for Fluo Recipes.
 
 ```xml
   <properties>
-    <fluo-recipes.version>1.0.0-beta-2</fluo-recipes.version>
+    <fluo-recipes.version>1.0.0-incubating</fluo-recipes.version>
   </properties>
 
   <dependencies>

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/common/RowRange.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/common/RowRange.java
@@ -71,7 +71,6 @@ public class RowRange {
     }
   }
 
-
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/data/RowHasher.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/data/RowHasher.java
@@ -69,7 +69,6 @@ public class RowHasher {
     return tableOptim;
   }
 
-
   private Bytes prefix;
 
   public RowHasher(String prefix) {

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportBucket.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportBucket.java
@@ -100,7 +100,6 @@ class ExportBucket {
         + ((seq.byteAt(6) & 255) << 8) + ((seq.byteAt(7) & 255) << 0));
   }
 
-
   public void add(long seq, byte[] key, byte[] value) {
     Bytes row =
         Bytes.newBuilder(bucketRow.length() + 1 + key.length + 8).append(bucketRow).append(":")

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportQueue.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportQueue.java
@@ -170,6 +170,9 @@ public class ExportQueue<K, V> {
     return tableOptim;
   }
 
+  /**
+   * @since 1.0.0
+   */
   public static class Options {
 
     private static final String PREFIX = "recipes.exportQueue.";
@@ -207,7 +210,6 @@ public class ExportQueue<K, V> {
       this.keyType = keyType;
       this.valueType = valueType;
     }
-
 
     public <K, V> Options(String queueId, Class<? extends Exporter<K, V>> exporter,
         Class<K> keyType, Class<V> valueType, int buckets) {

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMap.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMap.java
@@ -402,6 +402,8 @@ public class CollisionFreeMap<K, V> {
 
   /**
    * @see CollisionFreeMap#getInitializer(String, int, SimpleSerializer)
+   *
+   * @since 1.0.0
    */
   public static class Initializer<K2, V2> implements Serializable {
 
@@ -432,6 +434,9 @@ public class CollisionFreeMap<K, V> {
     }
   }
 
+  /**
+   * @since 1.0.0
+   */
   public static class Options {
 
     static final long DEFAULT_BUFFER_SIZE = 1 << 22;

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/serialization/SimpleSerializer.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/serialization/SimpleSerializer.java
@@ -26,23 +26,23 @@ public interface SimpleSerializer {
   /**
    * Called immediately after construction and passed Fluo application configuration.
    */
-  public void init(SimpleConfiguration appConfig);
+  void init(SimpleConfiguration appConfig);
 
   // TODO refactor to support reuse of objects and byte arrays???
-  public <T> byte[] serialize(T obj);
+  <T> byte[] serialize(T obj);
 
-  public <T> T deserialize(byte[] serObj, Class<T> clazz);
+  <T> T deserialize(byte[] serObj, Class<T> clazz);
 
-  public static void setSetserlializer(FluoConfiguration fluoConfig,
+  static void setSerializer(FluoConfiguration fluoConfig,
       Class<? extends SimpleSerializer> serializerType) {
-    setSetserlializer(fluoConfig, serializerType.getName());
+    setSerializer(fluoConfig, serializerType.getName());
   }
 
-  public static void setSetserlializer(FluoConfiguration fluoConfig, String serializerType) {
+  static void setSerializer(FluoConfiguration fluoConfig, String serializerType) {
     fluoConfig.getAppConfiguration().setProperty("recipes.serializer", serializerType);
   }
 
-  public static SimpleSerializer getInstance(SimpleConfiguration appConfig) {
+  static SimpleSerializer getInstance(SimpleConfiguration appConfig) {
     String serType =
         appConfig.getString("recipes.serializer",
             "org.apache.fluo.recipes.kryo.KryoSimplerSerializer");

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/transaction/LogEntry.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/transaction/LogEntry.java
@@ -28,6 +28,9 @@ import org.apache.fluo.api.data.Column;
  */
 public class LogEntry {
 
+  /**
+   * @since 1.0.0
+   */
   public enum Operation {
     GET, SET, DELETE
   }

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/export/ExportTestBase.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/export/ExportTestBase.java
@@ -144,7 +144,7 @@ public class ExportTestBase {
     ObserverConfiguration doc = new ObserverConfiguration(DocumentObserver.class.getName());
     props.addObserver(doc);
 
-    SimpleSerializer.setSetserlializer(props, GsonSerializer.class);
+    SimpleSerializer.setSerializer(props, GsonSerializer.class);
 
     ExportQueue.Options exportQueueOpts =
         new ExportQueue.Options(RefExporter.QUEUE_ID, RefExporter.class, String.class,

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/BigUpdateIT.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/BigUpdateIT.java
@@ -116,7 +116,7 @@ public class BigUpdateIT {
     props.setWorkerThreads(20);
     props.setMiniDataDir("target/mini");
 
-    SimpleSerializer.setSetserlializer(props, TestSerializer.class);
+    SimpleSerializer.setSerializer(props, TestSerializer.class);
 
     CollisionFreeMap.configure(props, new CollisionFreeMap.Options(MAP_ID, LongCombiner.class,
         MyObserver.class, String.class, Long.class, 2).setBufferSize(1 << 10));

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/CollisionFreeMapIT.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/CollisionFreeMapIT.java
@@ -59,7 +59,7 @@ public class CollisionFreeMapIT {
 
     props.addObserver(new ObserverConfiguration(DocumentObserver.class.getName()));
 
-    SimpleSerializer.setSetserlializer(props, TestSerializer.class);
+    SimpleSerializer.setSerializer(props, TestSerializer.class);
 
     CollisionFreeMap.configure(props, new CollisionFreeMap.Options(MAP_ID, WordCountCombiner.class,
         WordCountObserver.class, String.class, Long.class, 17));

--- a/modules/kryo/src/main/java/org/apache/fluo/recipes/kryo/KryoSimplerSerializer.java
+++ b/modules/kryo/src/main/java/org/apache/fluo/recipes/kryo/KryoSimplerSerializer.java
@@ -64,6 +64,9 @@ public class KryoSimplerSerializer implements SimpleSerializer, Serializable {
     }
   }
 
+  /**
+   * @since 1.0.0
+   */
   public static class DefaultFactory implements KryoFactory {
     @Override
     public Kryo create() {
@@ -117,7 +120,6 @@ public class KryoSimplerSerializer implements SimpleSerializer, Serializable {
   /**
    * Call this to configure a KryoFactory type before initializing Fluo.
    */
-
   public static void setKryoFactory(FluoConfiguration config, String factoryType) {
     config.getAppConfiguration().setProperty(KRYO_FACTORY_PROP, factoryType);
   }
@@ -125,7 +127,6 @@ public class KryoSimplerSerializer implements SimpleSerializer, Serializable {
   /**
    * Call this to configure a KryoFactory type before initializing Fluo.
    */
-
   public static void setKryoFactory(FluoConfiguration config,
       Class<? extends KryoFactory> factoryType) {
     config.getAppConfiguration().setProperty(KRYO_FACTORY_PROP, factoryType.getName());

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/AccumuloRangePartitioner.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/AccumuloRangePartitioner.java
@@ -52,5 +52,4 @@ public class AccumuloRangePartitioner extends Partitioner {
   public int numPartitions() {
     return splits.size() + 1;
   }
-
 }

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
@@ -250,6 +250,8 @@ public class FluoSparkHelper {
 
   /**
    * Optional settings for Bulk Imports
+   *
+   * @since 1.0.0
    */
   public static class BulkImportOptions {
 

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkTestUtil.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkTestUtil.java
@@ -18,7 +18,6 @@ package org.apache.fluo.recipes.spark;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 
-
 /**
  * Utility code for Fluo/Spark testing
  *
@@ -40,5 +39,4 @@ public class FluoSparkTestUtil {
     sparkConf.set("spark.ui.port", "4444");
     return new JavaSparkContext(sparkConf);
   }
-
 }

--- a/modules/test/src/main/java/org/apache/fluo/recipes/test/AccumuloExportITBase.java
+++ b/modules/test/src/main/java/org/apache/fluo/recipes/test/AccumuloExportITBase.java
@@ -175,7 +175,6 @@ public class AccumuloExportITBase {
 
   }
 
-
   /**
    * This method is intended to be overridden. The method is called before each test after Fluo is
    * initialized before MiniFluo is started.

--- a/modules/test/src/main/java/org/apache/fluo/recipes/test/FluoITHelper.java
+++ b/modules/test/src/main/java/org/apache/fluo/recipes/test/FluoITHelper.java
@@ -292,7 +292,6 @@ public class FluoITHelper {
    * A helper method for parsing test data. Each string passed in is split using the specified
    * splitter into four fields for row, family, qualifier, and value.
    */
-
   public static List<RowColumnValue> parse(Splitter splitter, String... data) {
     ArrayList<RowColumnValue> ret = new ArrayList<>();
 
@@ -312,6 +311,4 @@ public class FluoITHelper {
 
     return ret;
   }
-
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </parent>
   <groupId>org.apache.fluo</groupId>
   <artifactId>fluo-recipes-parent</artifactId>
-  <version>1.0.0-beta-3-SNAPSHOT</version>
+  <version>1.0.0-incubating-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Fluo Recipes Parent</name>
   <description>Implementation of Common Fluo patterns</description>
@@ -51,7 +51,7 @@
     <url>https://github.com/apache/incubator-fluo-recipes/issues</url>
   </issueManagement>
   <properties>
-    <accumulo.version>1.7.1</accumulo.version>
+    <accumulo.version>1.6.5</accumulo.version>
     <findbugs.maxRank>13</findbugs.maxRank>
     <fluo.version>1.0.0-incubating-SNAPSHOT</fluo.version>
     <hadoop.version>2.6.3</hadoop.version>
@@ -202,6 +202,13 @@
                 <Sealed>false</Sealed>
               </manifestEntries>
             </archive>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <excludePackageNames>*.impl.*</excludePackageNames>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
* Set version to 1.0.0-incubating-SNAPSHOT
* Removed unnecessary whitespace
* Added missing @since tags
* Excluded *.impl.* packages from javadocs
* Removed unnecessary public modifiers from public interface methods
* Fixed method misspelling in SimpleSerializer
* Set Accumulo min version in pom.xml to 1.6.5 to match Fluo