### PR TITLE
add missing dependency on commons collections

### DIFF
--- a/modules/accumulo/pom.xml
+++ b/modules/accumulo/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.fluo</groupId>
     <artifactId>fluo-recipes-parent</artifactId>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <version>1.0.0-incubating-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-recipes-accumulo</artifactId>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.fluo</groupId>
     <artifactId>fluo-recipes-parent</artifactId>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <version>1.0.0-incubating-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-recipes-core</artifactId>
@@ -28,6 +28,10 @@
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
       <version>3.0.3</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.fluo</groupId>

--- a/modules/kryo/pom.xml
+++ b/modules/kryo/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.fluo</groupId>
     <artifactId>fluo-recipes-parent</artifactId>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <version>1.0.0-incubating-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-recipes-kryo</artifactId>

--- a/modules/spark/pom.xml
+++ b/modules/spark/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.fluo</groupId>
     <artifactId>fluo-recipes-parent</artifactId>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <version>1.0.0-incubating-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-recipes-spark</artifactId>

--- a/modules/test/pom.xml
+++ b/modules/test/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.fluo</groupId>
     <artifactId>fluo-recipes-parent</artifactId>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <version>1.0.0-incubating-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>fluo-recipes-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.1</version>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>


### PR DESCRIPTION
When Fluo changed to remove a dependency on commons collections (because it was not using it), this broke recipes which was using it but did not declare it.