### PR TITLE
Fix small compiler warning in IT

### DIFF
--- a/modules/spark/src/test/java/org/apache/fluo/recipes/spark/it/FluoSparkHelperIT.java
+++ b/modules/spark/src/test/java/org/apache/fluo/recipes/spark/it/FluoSparkHelperIT.java
@@ -75,6 +75,7 @@ public class FluoSparkHelperIT extends AccumuloExportITBase {
         new FluoSparkHelper.BulkImportOptions());
 
     try (MiniFluo miniFluo = FluoFactory.newMiniFluo(getFluoConfiguration())) {
+      Assert.assertNotNull(miniFluo);
       Assert.assertTrue(FluoITHelper.verifyFluoTable(getFluoConfiguration(), expected));
 
       List<RowColumnValue> actualRead = FluoSparkHelper.toRcvRDD(fsh.readFromFluo(ctx)).collect();


### PR DESCRIPTION
Make use of resource inside of try-with-resources block by ensuring it's
not null.